### PR TITLE
display error to user if no stories can't be pulled

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,25 @@
 # Raycast - Hacker News
 
+## Overview
+
+- This is an UNPUBLISHED extension for Raycast that shows the top stories from Hacker News.
+- Raycast is available for macOS now, and there is a waitlist for Windows.
+- This repository was initialized using the 'Create Extension' command in Raycast. Instructions for this can be found here: https://developers.raycast.com/basics/create-your-first-extension
+
+## Requirements
+- Raycast 1.26.0 or higher installed (macOS)
+- Node.js 22.14 or higher installed
+- npm 7 or higher
+- familiarity with React and TypeScript. 
+  - Don't worry, you don't need to be an expert. If you need some help with the basics, check out TypeScript's [Handbook](https://www.typescriptlang.org/docs/handbook/intro.html) and React's [Getting Started](https://react.dev/learn) guide.
+
 ## Build the extension
-Open your terminal, navigate to your extension directory and run `npm install && npm run dev`. 
-Open Raycast, and you'll notice your extension at the top of the root search. 
-Press ↵ to open it.
+- Open your terminal, navigate to the `raycast---hacker-news` extension directory and run `npm install && npm run dev`. 
+- Open Raycast, and you'll notice the extension at the top of the root search. 
+- Press Enter to open it.
+- You should see a list of the top stories from Hacker News.
+
+## Functionality
+- double-click on a story to open it in your default browser.
+- press Enter to open it in your default browser.
+- press Command + K to open options.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 - This is an UNPUBLISHED extension for Raycast that shows the top stories from Hacker News.
 - Raycast is available for macOS now, and there is a waitlist for Windows.
-- This repository was initialized using the 'Create Extension' command in Raycast. Instructions for this can be found here: https://developers.raycast.com/basics/create-your-first-extension
+- This repository was initialized using the 'Create Extension' command in Raycast. Instructions for this can be found here: <https://developers.raycast.com/basics/create-your-first-extension>
 
 ## Requirements
 - Raycast 1.26.0 or higher installed (macOS)

--- a/src/get-hacker-news.tsx
+++ b/src/get-hacker-news.tsx
@@ -49,26 +49,34 @@ export default function Command() {
 
   return (
     <List isLoading={!state.items && !state.error}>
-      {state.items?.map((item, index) => (
-        <List.Item
-          key={item.guid || index}
-          title={item.title || 'No title'}
-          subtitle={item.creator || 'Unknown author'}
-          accessories={[
-            { text: item.pubDate ? new Date(item.pubDate).toLocaleDateString() : '' },
-          ]}
-          actions={
-            <ActionPanel>
-              <Action.OpenInBrowser url={item.link || ''} />
-              <Action.CopyToClipboard
-                title="Copy URL"
-                content={item.link || ''}
-                shortcut={{ modifiers: ["cmd"], key: "." }}
-              />
-            </ActionPanel>
-          }
+      {state.error ? (
+        <List.EmptyView
+          title="Error loading Hacker News"
+          description={state.error.message || String(state.error)}
+          icon={Icon.ExclamationMark}
         />
-      ))}
+      ) : (
+        state.items?.map((item, index) => (
+          <List.Item
+            key={item.guid || index}
+            title={item.title || 'No title'}
+            subtitle={item.creator || 'Unknown author'}
+            accessories={[
+              { text: item.pubDate ? new Date(item.pubDate).toLocaleDateString() : '' },
+            ]}
+            actions={
+              <ActionPanel>
+                <Action.OpenInBrowser url={item.link || ''} />
+                <Action.CopyToClipboard
+                  title="Copy URL"
+                  content={item.link || ''}
+                  shortcut={{ modifiers: ["cmd"], key: "." }}
+                />
+              </ActionPanel>
+            }
+          />
+        ))
+      )}
     </List>
   );
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added README sections: Overview, Requirements, and Functionality
  * Clarified build instructions with the specific directory and explicit step actions (e.g., press Enter)
  * Minor wording improvements and added a list of top Hacker News stories

* **New Features**
  * Added an error state in the story list with a descriptive message and icon when retrieval fails
<!-- end of auto-generated comment: release notes by coderabbit.ai -->